### PR TITLE
Add some extra configuration files to /etc

### DIFF
--- a/board/sedna-riscv64/rootfs-overlay/etc/bashrc.d/history.bash
+++ b/board/sedna-riscv64/rootfs-overlay/etc/bashrc.d/history.bash
@@ -1,0 +1,4 @@
+# Save history on each command, instead of on shell exit.
+# Especially important if this is the default shell, because `poweroff` does not
+# run the usual history-saving exit functionality.
+PROMPT_COMMAND='history -a'

--- a/board/sedna-riscv64/rootfs-overlay/etc/nanorc
+++ b/board/sedna-riscv64/rootfs-overlay/etc/nanorc
@@ -1,0 +1,4 @@
+## Uncomment these lines to enable syntax highlighting.  This may cause
+## slow performance on low-end CPUs
+# include "/usr/share/nano/*.nanorc"
+# include "/usr/share/nano/extra/*.nanorc"


### PR DESCRIPTION
Probably better to include these by default.  I expect several people will want nano syntax highlighting if itʼs as easy as uncommenting a line or two, and better not to have to learn the hard way about Bash losing history.

To go with the bash one, I looked for ways to change a userʼs shell other than manually editing `/etc/passwd`.  It looks like buildroot includes two: `chsh` from `util-linux` and `usermod` in `shadow`.  I didnʼt want to add PAM to the system for the first, and the shadow package is pretty heavy for something most people probably donʼt want.  (Now, if we can find some way to treat “currently using the OC2R computer block” as a PAM module, then PAM might be worth it.)  Itʼd be nice if BusyBox had its own `chsh`, but it doesnʼt.