### PR TITLE
Update MICROPYPATH to still include installed libraries

### DIFF
--- a/board/sedna-riscv64/rootfs-overlay/etc/profile.d/python_path.sh
+++ b/board/sedna-riscv64/rootfs-overlay/etc/profile.d/python_path.sh
@@ -1,5 +1,7 @@
 if [ -z "$MICROPYPATH" ]; then
-    export MICROPYPATH="/mnt/builtin/lib/micropython"
+    # MICROPYPATH, unlike PYTHONPATH, overrides the whole path; we need to
+    # append the default value (from ports/unix/mpconfigport.h)
+    export MICROPYPATH="/mnt/builtin/lib/micropython:.frozen:~/.micropython/lib:/usr/lib/micropython"
 else
     export MICROPYPATH="$MICROPYPATH:/mnt/builtin/lib/micropython"
 fi


### PR DESCRIPTION
The rest of PR #10.  It still does the actual work to close #4, and it still depends on North-Western-Development/oc2r#122.  Without this, the other micropython libraries are on the computer but hard to access.